### PR TITLE
improvement(test): update eval_part generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ change the first three line for your situation
 load_path = './workdirs/epoch_xxx'                               # must have generator_module.mge file in folder epoch_xxx, xxx is digital
 dataroot = "pathtoyourdataset/train/train_sharp_bicubic"
 exp_name = 'basicVSR_track1_test_for_validation'                # any name you like
+eval_part = tuple(map(str, ["{0:03}".format(x) for x in range(240, 270)]))  # make sure index existed in the dataroot
 ```
 
 and then , run  it:

--- a/configs/restorers/BasicVSR/basicVSR_test_valid.py
+++ b/configs/restorers/BasicVSR/basicVSR_test_valid.py
@@ -1,7 +1,7 @@
 load_path = './workdirs/epoch_24'
 dataroot = "pathtoyourdataset/train/train_sharp_bicubic"
 exp_name = 'basicVSR_track1_test_for_validation'
-eval_part = tuple(map(str, range(240, 270)))
+eval_part = tuple(map(str, ["{0:03}".format(x) for x in range(240, 270)]))
 # you can custom values before, for the following params do not change if you are new to this project
 ###########################################################################################
 # please make sure your gpu has 11GB memory at least, otherwise it will OOM


### PR DESCRIPTION
If use `test_sharp_bicubic` to test pretrained model,  '240-270' not existed in the dataset.
The old code not support 'range(0,19)' .